### PR TITLE
feat: Create build script for self-contained HTML

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+
+const srcDir = path.join(__dirname, 'src');
+const distDir = path.join(__dirname, 'dist');
+
+const htmlFilePath = path.join(srcDir, 'index.html');
+const jsonFilePath = path.join(srcDir, 'survey.json');
+const cssFilePath = path.join(srcDir, 'style.css');
+const jsFilePath = path.join(srcDir, 'app.js');
+
+const outputHtmlPath = path.join(distDir, 'survey.html');
+
+try {
+    // 1. Ensure dist directory exists
+    if (!fs.existsSync(distDir)) {
+        fs.mkdirSync(distDir);
+    }
+
+    // 2. Read all source files
+    let htmlContent = fs.readFileSync(htmlFilePath, 'utf8');
+    const jsonContent = fs.readFileSync(jsonFilePath, 'utf8');
+    const cssContent = fs.readFileSync(cssFilePath, 'utf8');
+    const jsContent = fs.readFileSync(jsFilePath, 'utf8');
+
+    // 3. Embed CSS
+    // Replace <link rel="stylesheet" href="style.css"> with <style>...</style>
+    htmlContent = htmlContent.replace(
+        '<link rel="stylesheet" href="style.css">',
+        `<style>${cssContent}</style>`
+    );
+
+    // 4. Embed JSON data
+    // We will add a script tag with the JSON content before the main app script.
+    const jsonScript = `<script id="survey-data" type="application/json">${jsonContent}</script>`;
+
+    // 5. Embed JavaScript
+    // Replace <script src="app.js"></script> with <script>...</script>
+    htmlContent = htmlContent.replace(
+        '<script src="app.js"></script>',
+        `${jsonScript}\n<script>${jsContent}</script>`
+    );
+
+    // 6. Write the final, self-contained HTML file
+    fs.writeFileSync(outputHtmlPath, htmlContent);
+
+    console.log(`Successfully created self-contained survey at: ${outputHtmlPath}`);
+
+} catch (error) {
+    console.error('Error during build process:', error);
+    process.exit(1);
+}

--- a/dist/survey.html
+++ b/dist/survey.html
@@ -1,0 +1,565 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Survey</title>
+    <style>/* Basic styling for the survey app */
+body {
+    font-family: sans-serif;
+    background-color: #f4f4f9;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    margin: 0;
+}
+
+#survey-container {
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    width: 100%;
+    max-width: 600px;
+    padding: 2rem;
+    margin: 1rem;
+}
+
+#survey-header {
+    text-align: center;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 1rem;
+    margin-bottom: 1rem;
+}
+
+.survey-screen {
+    /* Screens are managed by JS */
+}
+
+button {
+    background-color: #007bff;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1rem;
+    margin-top: 1rem;
+}
+
+button:hover {
+    background-color: #0056b3;
+}
+
+#navigation-container {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 2rem;
+}
+
+.field-wrapper {
+    margin-bottom: 1.5rem;
+}
+
+.field-wrapper label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: bold;
+}
+
+.field-wrapper input[type="text"],
+.field-wrapper textarea,
+.field-wrapper select {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box; /* Important */
+}
+
+.field-wrapper input[type="radio"] {
+    margin-right: 0.5rem;
+}
+
+.error-message {
+    color: #dc3545;
+    font-size: 0.875rem;
+    margin-top: 0.25rem;
+    display: block; /* To ensure it appears on its own line */
+}
+
+#summary-container ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+#summary-container li {
+    background-color: #f8f9fa;
+    padding: 10px;
+    border-bottom: 1px solid #eee;
+}
+
+#summary-container li:last-child {
+    border-bottom: none;
+}
+</style>
+</head>
+<body>
+    <div id="survey-container">
+        <header id="survey-header">
+            <h1 id="survey-title"></h1>
+            <p id="survey-description"></p>
+        </header>
+
+        <main id="survey-main">
+            <!-- Start Screen: Initially visible -->
+            <div id="start-screen" class="survey-screen">
+                <h2 id="start-screen-title"></h2>
+                <p id="start-screen-description"></p>
+                <button id="start-button"></button>
+            </div>
+
+            <!-- Survey Screen: Initially hidden -->
+            <div id="survey-screen" class="survey-screen" style="display: none;">
+                <div id="step-header">
+                    <h3 id="step-title"></h3>
+                </div>
+                <div id="fields-container">
+                    <!-- Dynamic fields will be inserted here -->
+                </div>
+                <div id="navigation-container">
+                    <button id="back-button">Back</button>
+                    <button id="next-button">Next</button>
+                </div>
+            </div>
+
+            <!-- End Screen: Initially hidden -->
+            <div id="end-screen" class="survey-screen" style="display: none;">
+                <h2 id="end-screen-title"></h2>
+                <p id="end-screen-description"></p>
+                <div id="summary-container">
+                    <!-- Review of answers will be shown here -->
+                </div>
+                <button id="review-button"></button>
+                <button id="submit-button"></button>
+            </div>
+        </main>
+    </div>
+
+    <script id="survey-data" type="application/json">{
+  "surveyTitle": "Customer Feedback Survey",
+  "surveyDescription": "Thank you for taking the time to provide us with your valuable feedback.",
+  "startScreen": {
+    "title": "Welcome!",
+    "description": "This survey will take about 5 minutes to complete.",
+    "buttonText": "Start Survey"
+  },
+  "steps": [
+    {
+      "stepId": "step1",
+      "title": "Your Information",
+      "fields": [
+        {
+          "fieldId": "name",
+          "type": "text",
+          "label": "What is your full name?",
+          "placeholder": "e.g., Jane Doe",
+          "validation": {
+            "required": true,
+            "minLength": 2
+          }
+        },
+        {
+          "fieldId": "email",
+          "type": "text",
+          "label": "What is your email address?",
+          "placeholder": "e.g., jane.doe@example.com",
+          "validation": {
+            "required": true,
+            "pattern": "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$"
+          }
+        }
+      ]
+    },
+    {
+      "stepId": "step2",
+      "title": "Your Experience",
+      "fields": [
+        {
+          "fieldId": "rating",
+          "type": "radio",
+          "label": "How would you rate your overall experience?",
+          "options": [
+            { "label": "Excellent", "value": "excellent" },
+            { "label": "Good", "value": "good" },
+            { "label": "Average", "value": "average" },
+            { "label": "Poor", "value": "poor" }
+          ],
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "fieldId": "product",
+          "type": "dropdown",
+          "label": "Which product did you use?",
+          "options": [
+            { "label": "Select a product...", "value": "" },
+            { "label": "Product A", "value": "prod-a" },
+            { "label": "Product B", "value": "prod-b" },
+            { "label": "Product C", "value": "prod-c" }
+          ],
+          "validation": {
+            "required": true
+          }
+        }
+      ]
+    },
+    {
+      "stepId": "step3",
+      "title": "Feedback",
+      "fields": [
+        {
+          "fieldId": "comments",
+          "type": "textarea",
+          "label": "Do you have any additional comments or suggestions?",
+          "placeholder": "Your feedback is important to us...",
+          "validation": {
+            "required": false,
+            "maxLength": 500
+          }
+        }
+      ]
+    }
+  ],
+  "endScreen": {
+    "title": "Thank You!",
+    "description": "Your feedback has been recorded. You can now review your answers or submit.",
+    "reviewButtonText": "Review Answers",
+    "submitButtonText": "Submit"
+  }
+}
+</script>
+<script>document.addEventListener('DOMContentLoaded', () => {
+    // State management
+    let surveyData = null;
+    let currentStepIndex = 0;
+    const userResponses = {};
+
+    // DOM element references
+    const surveyContainer = document.getElementById('survey-container');
+    const surveyTitleEl = document.getElementById('survey-title');
+    const surveyDescriptionEl = document.getElementById('survey-description');
+
+    const startScreen = document.getElementById('start-screen');
+    const startScreenTitleEl = document.getElementById('start-screen-title');
+    const startScreenDescriptionEl = document.getElementById('start-screen-description');
+    const startButton = document.getElementById('start-button');
+
+    const surveyScreen = document.getElementById('survey-screen');
+    const stepTitleEl = document.getElementById('step-title');
+    const fieldsContainer = document.getElementById('fields-container');
+    const backButton = document.getElementById('back-button');
+    const nextButton = document.getElementById('next-button');
+
+    const endScreen = document.getElementById('end-screen');
+    const endScreenTitleEl = document.getElementById('end-screen-title');
+    const endScreenDescriptionEl = document.getElementById('end-screen-description');
+    const summaryContainer = document.getElementById('summary-container');
+    const reviewButton = document.getElementById('review-button');
+    const submitButton = document.getElementById('submit-button');
+
+    /**
+     * Loads survey data from an embedded JSON script tag.
+     */
+    function loadSurveyFromEmbed() {
+        try {
+            const surveyDataEl = document.getElementById('survey-data');
+            if (!surveyDataEl) {
+                throw new Error('Survey data script tag not found.');
+            }
+            surveyData = JSON.parse(surveyDataEl.textContent);
+            initializeSurvey();
+        } catch (error) {
+            console.error("Could not load embedded survey data:", error);
+            surveyContainer.innerHTML = '<p>Error loading survey data. The file might be corrupted.</p>';
+        }
+    }
+
+    /**
+     * Initializes the survey by rendering the start screen.
+     */
+    function initializeSurvey() {
+        // Populate survey header
+        surveyTitleEl.textContent = surveyData.surveyTitle;
+        surveyDescriptionEl.textContent = surveyData.surveyDescription;
+
+        // Populate start screen
+        const { startScreen: startScreenData } = surveyData;
+        startScreenTitleEl.textContent = startScreenData.title;
+        startScreenDescriptionEl.textContent = startScreenData.description;
+        startButton.textContent = startScreenData.buttonText;
+
+        // Add event listeners
+        startButton.addEventListener('click', handleStart);
+        nextButton.addEventListener('click', handleNext);
+        backButton.addEventListener('click', handleBack);
+    }
+
+    /**
+     * Hides all screens and shows the one with the specified ID.
+     * @param {string} screenId - The ID of the screen to show.
+     */
+    function showScreen(screenId) {
+        document.querySelectorAll('.survey-screen').forEach(screen => {
+            screen.style.display = 'none';
+        });
+        document.getElementById(screenId).style.display = 'block';
+    }
+
+    /**
+     * Handles the start of the survey.
+     */
+    function handleStart() {
+        showScreen('survey-screen');
+        renderStep(currentStepIndex);
+    }
+
+    /**
+     * Renders a single step of the survey.
+     * @param {number} stepIndex - The index of the step to render.
+     */
+    function renderStep(stepIndex) {
+        const stepData = surveyData.steps[stepIndex];
+        stepTitleEl.textContent = stepData.title;
+        fieldsContainer.innerHTML = ''; // Clear previous fields
+
+        stepData.fields.forEach(field => {
+            const fieldEl = createField(field);
+            fieldsContainer.appendChild(fieldEl);
+        });
+
+        // Update navigation buttons
+        backButton.style.display = stepIndex === 0 ? 'none' : 'inline-block';
+        nextButton.textContent = (stepIndex === surveyData.steps.length - 1) ? 'Finish' : 'Next';
+    }
+
+    /**
+     * Creates the HTML element for a single field.
+     * @param {object} fieldData - The configuration for the field.
+     * @returns {HTMLElement} The created field element.
+     */
+    function createField(fieldData) {
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('field-wrapper');
+
+        const label = document.createElement('label');
+        label.textContent = fieldData.label;
+        label.setAttribute('for', fieldData.fieldId);
+        wrapper.appendChild(label);
+
+        let input;
+        switch (fieldData.type) {
+            case 'text':
+                input = document.createElement('input');
+                input.type = 'text';
+                input.placeholder = fieldData.placeholder || '';
+                break;
+            case 'textarea':
+                input = document.createElement('textarea');
+                input.placeholder = fieldData.placeholder || '';
+                break;
+            case 'radio':
+                // For radio, the wrapper contains multiple inputs
+                fieldData.options.forEach(option => {
+                    const radioWrapper = document.createElement('div');
+                    const radioInput = document.createElement('input');
+                    radioInput.type = 'radio';
+                    radioInput.name = fieldData.fieldId;
+                    radioInput.id = `${fieldData.fieldId}-${option.value}`;
+                    radioInput.value = option.value;
+
+                    const radioLabel = document.createElement('label');
+                    radioLabel.textContent = option.label;
+                    radioLabel.setAttribute('for', radioInput.id);
+
+                    radioWrapper.appendChild(radioInput);
+                    radioWrapper.appendChild(radioLabel);
+                    wrapper.appendChild(radioWrapper);
+                });
+                return wrapper; // Return early as the structure is different
+            case 'dropdown':
+                input = document.createElement('select');
+                fieldData.options.forEach(option => {
+                    const opt = document.createElement('option');
+                    opt.value = option.value;
+                    opt.textContent = option.label;
+                    input.appendChild(opt);
+                });
+                break;
+        }
+
+        if (input) {
+            input.id = fieldData.fieldId;
+            // Add validation attributes
+            if (fieldData.validation?.required) {
+                input.required = true;
+            }
+            if (fieldData.validation?.minLength) {
+                input.minLength = fieldData.validation.minLength;
+            }
+            if (fieldData.validation?.maxLength) {
+                input.maxLength = fieldData.validation.maxLength;
+            }
+            if (fieldData.validation?.pattern) {
+                input.pattern = fieldData.validation.pattern;
+            }
+            wrapper.appendChild(input);
+        }
+
+        const errorEl = document.createElement('span');
+        errorEl.classList.add('error-message');
+        errorEl.id = `${fieldData.fieldId}-error`;
+        wrapper.appendChild(errorEl);
+
+        return wrapper;
+    }
+
+    /**
+     * Validates the current step, saves responses, and then proceeds.
+     */
+    function handleNext() {
+        if (validateAndSaveStep()) {
+            if (currentStepIndex < surveyData.steps.length - 1) {
+                currentStepIndex++;
+                renderStep(currentStepIndex);
+            } else {
+                renderEndScreen();
+            }
+        }
+    }
+
+    /**
+     * Validates fields in the current step and saves their values.
+     * @returns {boolean} - True if validation passes, false otherwise.
+     */
+    function validateAndSaveStep() {
+        let isValid = true;
+        const stepData = surveyData.steps[currentStepIndex];
+
+        // Clear previous errors for this step
+        stepData.fields.forEach(field => {
+            const errorEl = document.getElementById(`${field.fieldId}-error`);
+            if (errorEl) errorEl.textContent = '';
+        });
+
+        for (const field of stepData.fields) {
+            const fieldEl = document.getElementById(field.fieldId);
+            let value;
+            let fieldIsValid = true;
+
+            if (field.type === 'radio') {
+                const checkedRadio = document.querySelector(`input[name="${field.fieldId}"]:checked`);
+                value = checkedRadio ? checkedRadio.value : null;
+            } else {
+                value = fieldEl.value;
+            }
+
+            // Save response
+            userResponses[field.fieldId] = value;
+
+            // Perform validation
+            if (field.validation?.required && !value) {
+                fieldIsValid = false;
+                showError(field.fieldId, 'This field is required.');
+            } else if (value) {
+                if (field.validation?.minLength && value.length < field.validation.minLength) {
+                    fieldIsValid = false;
+                    showError(field.fieldId, `Must be at least ${field.validation.minLength} characters.`);
+                }
+                if (field.validation?.maxLength && value.length > field.validation.maxLength) {
+                    fieldIsValid = false;
+                    showError(field.fieldId, `Cannot exceed ${field.validation.maxLength} characters.`);
+                }
+                if (field.validation?.pattern) {
+                    const regex = new RegExp(field.validation.pattern);
+                    if (!regex.test(value)) {
+                        fieldIsValid = false;
+                        showError(field.fieldId, 'Invalid format.');
+                    }
+                }
+            }
+
+            if (!fieldIsValid) isValid = false;
+        }
+
+        return isValid;
+    }
+
+    /**
+     * Displays an error message for a specific field.
+     * @param {string} fieldId - The ID of the field.
+     * @param {string} message - The error message to display.
+     */
+    function showError(fieldId, message) {
+        const errorEl = document.getElementById(`${fieldId}-error`);
+        if (errorEl) {
+            errorEl.textContent = message;
+        }
+    }
+
+    /**
+     * Handles the back button click.
+     */
+    function handleBack() {
+        if (currentStepIndex > 0) {
+            currentStepIndex--;
+            renderStep(currentStepIndex);
+        }
+    }
+
+    /**
+     * Renders the final screen of the survey.
+     */
+    function renderEndScreen() {
+        showScreen('end-screen');
+        const { endScreen: endScreenData } = surveyData;
+        endScreenTitleEl.textContent = endScreenData.title;
+        endScreenDescriptionEl.textContent = endScreenData.description;
+        reviewButton.textContent = endScreenData.reviewButtonText;
+        submitButton.textContent = endScreenData.submitButtonText;
+
+        // Render summary
+        summaryContainer.innerHTML = ''; // Clear previous summary
+        const summaryList = document.createElement('ul');
+
+        surveyData.steps.forEach(step => {
+            step.fields.forEach(field => {
+                const response = userResponses[field.fieldId];
+                if (response) {
+                    const listItem = document.createElement('li');
+
+                    let responseText = response;
+                    if (field.type === 'radio' || field.type === 'dropdown') {
+                        const option = field.options.find(o => o.value === response);
+                        responseText = option ? option.label : response;
+                    }
+
+                    listItem.innerHTML = `<strong>${field.label}:</strong> ${responseText}`;
+                    summaryList.appendChild(listItem);
+                }
+            });
+        });
+
+        summaryContainer.appendChild(summaryList);
+
+        // TODO: Implement final submission logic for the submitButton
+        // TODO: Implement logic for reviewButton to go back to a specific step
+    }
+
+    // Initial load
+    loadSurveyFromEmbed();
+});
+</script>
+</body>
+</html>

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,320 @@
+document.addEventListener('DOMContentLoaded', () => {
+    // State management
+    let surveyData = null;
+    let currentStepIndex = 0;
+    const userResponses = {};
+
+    // DOM element references
+    const surveyContainer = document.getElementById('survey-container');
+    const surveyTitleEl = document.getElementById('survey-title');
+    const surveyDescriptionEl = document.getElementById('survey-description');
+
+    const startScreen = document.getElementById('start-screen');
+    const startScreenTitleEl = document.getElementById('start-screen-title');
+    const startScreenDescriptionEl = document.getElementById('start-screen-description');
+    const startButton = document.getElementById('start-button');
+
+    const surveyScreen = document.getElementById('survey-screen');
+    const stepTitleEl = document.getElementById('step-title');
+    const fieldsContainer = document.getElementById('fields-container');
+    const backButton = document.getElementById('back-button');
+    const nextButton = document.getElementById('next-button');
+
+    const endScreen = document.getElementById('end-screen');
+    const endScreenTitleEl = document.getElementById('end-screen-title');
+    const endScreenDescriptionEl = document.getElementById('end-screen-description');
+    const summaryContainer = document.getElementById('summary-container');
+    const reviewButton = document.getElementById('review-button');
+    const submitButton = document.getElementById('submit-button');
+
+    /**
+     * Loads survey data from an embedded JSON script tag.
+     */
+    function loadSurveyFromEmbed() {
+        try {
+            const surveyDataEl = document.getElementById('survey-data');
+            if (!surveyDataEl) {
+                throw new Error('Survey data script tag not found.');
+            }
+            surveyData = JSON.parse(surveyDataEl.textContent);
+            initializeSurvey();
+        } catch (error) {
+            console.error("Could not load embedded survey data:", error);
+            surveyContainer.innerHTML = '<p>Error loading survey data. The file might be corrupted.</p>';
+        }
+    }
+
+    /**
+     * Initializes the survey by rendering the start screen.
+     */
+    function initializeSurvey() {
+        // Populate survey header
+        surveyTitleEl.textContent = surveyData.surveyTitle;
+        surveyDescriptionEl.textContent = surveyData.surveyDescription;
+
+        // Populate start screen
+        const { startScreen: startScreenData } = surveyData;
+        startScreenTitleEl.textContent = startScreenData.title;
+        startScreenDescriptionEl.textContent = startScreenData.description;
+        startButton.textContent = startScreenData.buttonText;
+
+        // Add event listeners
+        startButton.addEventListener('click', handleStart);
+        nextButton.addEventListener('click', handleNext);
+        backButton.addEventListener('click', handleBack);
+    }
+
+    /**
+     * Hides all screens and shows the one with the specified ID.
+     * @param {string} screenId - The ID of the screen to show.
+     */
+    function showScreen(screenId) {
+        document.querySelectorAll('.survey-screen').forEach(screen => {
+            screen.style.display = 'none';
+        });
+        document.getElementById(screenId).style.display = 'block';
+    }
+
+    /**
+     * Handles the start of the survey.
+     */
+    function handleStart() {
+        showScreen('survey-screen');
+        renderStep(currentStepIndex);
+    }
+
+    /**
+     * Renders a single step of the survey.
+     * @param {number} stepIndex - The index of the step to render.
+     */
+    function renderStep(stepIndex) {
+        const stepData = surveyData.steps[stepIndex];
+        stepTitleEl.textContent = stepData.title;
+        fieldsContainer.innerHTML = ''; // Clear previous fields
+
+        stepData.fields.forEach(field => {
+            const fieldEl = createField(field);
+            fieldsContainer.appendChild(fieldEl);
+        });
+
+        // Update navigation buttons
+        backButton.style.display = stepIndex === 0 ? 'none' : 'inline-block';
+        nextButton.textContent = (stepIndex === surveyData.steps.length - 1) ? 'Finish' : 'Next';
+    }
+
+    /**
+     * Creates the HTML element for a single field.
+     * @param {object} fieldData - The configuration for the field.
+     * @returns {HTMLElement} The created field element.
+     */
+    function createField(fieldData) {
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('field-wrapper');
+
+        const label = document.createElement('label');
+        label.textContent = fieldData.label;
+        label.setAttribute('for', fieldData.fieldId);
+        wrapper.appendChild(label);
+
+        let input;
+        switch (fieldData.type) {
+            case 'text':
+                input = document.createElement('input');
+                input.type = 'text';
+                input.placeholder = fieldData.placeholder || '';
+                break;
+            case 'textarea':
+                input = document.createElement('textarea');
+                input.placeholder = fieldData.placeholder || '';
+                break;
+            case 'radio':
+                // For radio, the wrapper contains multiple inputs
+                fieldData.options.forEach(option => {
+                    const radioWrapper = document.createElement('div');
+                    const radioInput = document.createElement('input');
+                    radioInput.type = 'radio';
+                    radioInput.name = fieldData.fieldId;
+                    radioInput.id = `${fieldData.fieldId}-${option.value}`;
+                    radioInput.value = option.value;
+
+                    const radioLabel = document.createElement('label');
+                    radioLabel.textContent = option.label;
+                    radioLabel.setAttribute('for', radioInput.id);
+
+                    radioWrapper.appendChild(radioInput);
+                    radioWrapper.appendChild(radioLabel);
+                    wrapper.appendChild(radioWrapper);
+                });
+                return wrapper; // Return early as the structure is different
+            case 'dropdown':
+                input = document.createElement('select');
+                fieldData.options.forEach(option => {
+                    const opt = document.createElement('option');
+                    opt.value = option.value;
+                    opt.textContent = option.label;
+                    input.appendChild(opt);
+                });
+                break;
+        }
+
+        if (input) {
+            input.id = fieldData.fieldId;
+            // Add validation attributes
+            if (fieldData.validation?.required) {
+                input.required = true;
+            }
+            if (fieldData.validation?.minLength) {
+                input.minLength = fieldData.validation.minLength;
+            }
+            if (fieldData.validation?.maxLength) {
+                input.maxLength = fieldData.validation.maxLength;
+            }
+            if (fieldData.validation?.pattern) {
+                input.pattern = fieldData.validation.pattern;
+            }
+            wrapper.appendChild(input);
+        }
+
+        const errorEl = document.createElement('span');
+        errorEl.classList.add('error-message');
+        errorEl.id = `${fieldData.fieldId}-error`;
+        wrapper.appendChild(errorEl);
+
+        return wrapper;
+    }
+
+    /**
+     * Validates the current step, saves responses, and then proceeds.
+     */
+    function handleNext() {
+        if (validateAndSaveStep()) {
+            if (currentStepIndex < surveyData.steps.length - 1) {
+                currentStepIndex++;
+                renderStep(currentStepIndex);
+            } else {
+                renderEndScreen();
+            }
+        }
+    }
+
+    /**
+     * Validates fields in the current step and saves their values.
+     * @returns {boolean} - True if validation passes, false otherwise.
+     */
+    function validateAndSaveStep() {
+        let isValid = true;
+        const stepData = surveyData.steps[currentStepIndex];
+
+        // Clear previous errors for this step
+        stepData.fields.forEach(field => {
+            const errorEl = document.getElementById(`${field.fieldId}-error`);
+            if (errorEl) errorEl.textContent = '';
+        });
+
+        for (const field of stepData.fields) {
+            const fieldEl = document.getElementById(field.fieldId);
+            let value;
+            let fieldIsValid = true;
+
+            if (field.type === 'radio') {
+                const checkedRadio = document.querySelector(`input[name="${field.fieldId}"]:checked`);
+                value = checkedRadio ? checkedRadio.value : null;
+            } else {
+                value = fieldEl.value;
+            }
+
+            // Save response
+            userResponses[field.fieldId] = value;
+
+            // Perform validation
+            if (field.validation?.required && !value) {
+                fieldIsValid = false;
+                showError(field.fieldId, 'This field is required.');
+            } else if (value) {
+                if (field.validation?.minLength && value.length < field.validation.minLength) {
+                    fieldIsValid = false;
+                    showError(field.fieldId, `Must be at least ${field.validation.minLength} characters.`);
+                }
+                if (field.validation?.maxLength && value.length > field.validation.maxLength) {
+                    fieldIsValid = false;
+                    showError(field.fieldId, `Cannot exceed ${field.validation.maxLength} characters.`);
+                }
+                if (field.validation?.pattern) {
+                    const regex = new RegExp(field.validation.pattern);
+                    if (!regex.test(value)) {
+                        fieldIsValid = false;
+                        showError(field.fieldId, 'Invalid format.');
+                    }
+                }
+            }
+
+            if (!fieldIsValid) isValid = false;
+        }
+
+        return isValid;
+    }
+
+    /**
+     * Displays an error message for a specific field.
+     * @param {string} fieldId - The ID of the field.
+     * @param {string} message - The error message to display.
+     */
+    function showError(fieldId, message) {
+        const errorEl = document.getElementById(`${fieldId}-error`);
+        if (errorEl) {
+            errorEl.textContent = message;
+        }
+    }
+
+    /**
+     * Handles the back button click.
+     */
+    function handleBack() {
+        if (currentStepIndex > 0) {
+            currentStepIndex--;
+            renderStep(currentStepIndex);
+        }
+    }
+
+    /**
+     * Renders the final screen of the survey.
+     */
+    function renderEndScreen() {
+        showScreen('end-screen');
+        const { endScreen: endScreenData } = surveyData;
+        endScreenTitleEl.textContent = endScreenData.title;
+        endScreenDescriptionEl.textContent = endScreenData.description;
+        reviewButton.textContent = endScreenData.reviewButtonText;
+        submitButton.textContent = endScreenData.submitButtonText;
+
+        // Render summary
+        summaryContainer.innerHTML = ''; // Clear previous summary
+        const summaryList = document.createElement('ul');
+
+        surveyData.steps.forEach(step => {
+            step.fields.forEach(field => {
+                const response = userResponses[field.fieldId];
+                if (response) {
+                    const listItem = document.createElement('li');
+
+                    let responseText = response;
+                    if (field.type === 'radio' || field.type === 'dropdown') {
+                        const option = field.options.find(o => o.value === response);
+                        responseText = option ? option.label : response;
+                    }
+
+                    listItem.innerHTML = `<strong>${field.label}:</strong> ${responseText}`;
+                    summaryList.appendChild(listItem);
+                }
+            });
+        });
+
+        summaryContainer.appendChild(summaryList);
+
+        // TODO: Implement final submission logic for the submitButton
+        // TODO: Implement logic for reviewButton to go back to a specific step
+    }
+
+    // Initial load
+    loadSurveyFromEmbed();
+});

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Survey</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="survey-container">
+        <header id="survey-header">
+            <h1 id="survey-title"></h1>
+            <p id="survey-description"></p>
+        </header>
+
+        <main id="survey-main">
+            <!-- Start Screen: Initially visible -->
+            <div id="start-screen" class="survey-screen">
+                <h2 id="start-screen-title"></h2>
+                <p id="start-screen-description"></p>
+                <button id="start-button"></button>
+            </div>
+
+            <!-- Survey Screen: Initially hidden -->
+            <div id="survey-screen" class="survey-screen" style="display: none;">
+                <div id="step-header">
+                    <h3 id="step-title"></h3>
+                </div>
+                <div id="fields-container">
+                    <!-- Dynamic fields will be inserted here -->
+                </div>
+                <div id="navigation-container">
+                    <button id="back-button">Back</button>
+                    <button id="next-button">Next</button>
+                </div>
+            </div>
+
+            <!-- End Screen: Initially hidden -->
+            <div id="end-screen" class="survey-screen" style="display: none;">
+                <h2 id="end-screen-title"></h2>
+                <p id="end-screen-description"></p>
+                <div id="summary-container">
+                    <!-- Review of answers will be shown here -->
+                </div>
+                <button id="review-button"></button>
+                <button id="submit-button"></button>
+            </div>
+        </main>
+    </div>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,98 @@
+/* Basic styling for the survey app */
+body {
+    font-family: sans-serif;
+    background-color: #f4f4f9;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    margin: 0;
+}
+
+#survey-container {
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    width: 100%;
+    max-width: 600px;
+    padding: 2rem;
+    margin: 1rem;
+}
+
+#survey-header {
+    text-align: center;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 1rem;
+    margin-bottom: 1rem;
+}
+
+.survey-screen {
+    /* Screens are managed by JS */
+}
+
+button {
+    background-color: #007bff;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1rem;
+    margin-top: 1rem;
+}
+
+button:hover {
+    background-color: #0056b3;
+}
+
+#navigation-container {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 2rem;
+}
+
+.field-wrapper {
+    margin-bottom: 1.5rem;
+}
+
+.field-wrapper label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: bold;
+}
+
+.field-wrapper input[type="text"],
+.field-wrapper textarea,
+.field-wrapper select {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box; /* Important */
+}
+
+.field-wrapper input[type="radio"] {
+    margin-right: 0.5rem;
+}
+
+.error-message {
+    color: #dc3545;
+    font-size: 0.875rem;
+    margin-top: 0.25rem;
+    display: block; /* To ensure it appears on its own line */
+}
+
+#summary-container ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+#summary-container li {
+    background-color: #f8f9fa;
+    padding: 10px;
+    border-bottom: 1px solid #eee;
+}
+
+#summary-container li:last-child {
+    border-bottom: none;
+}

--- a/src/survey.json
+++ b/src/survey.json
@@ -1,0 +1,93 @@
+{
+  "surveyTitle": "Customer Feedback Survey",
+  "surveyDescription": "Thank you for taking the time to provide us with your valuable feedback.",
+  "startScreen": {
+    "title": "Welcome!",
+    "description": "This survey will take about 5 minutes to complete.",
+    "buttonText": "Start Survey"
+  },
+  "steps": [
+    {
+      "stepId": "step1",
+      "title": "Your Information",
+      "fields": [
+        {
+          "fieldId": "name",
+          "type": "text",
+          "label": "What is your full name?",
+          "placeholder": "e.g., Jane Doe",
+          "validation": {
+            "required": true,
+            "minLength": 2
+          }
+        },
+        {
+          "fieldId": "email",
+          "type": "text",
+          "label": "What is your email address?",
+          "placeholder": "e.g., jane.doe@example.com",
+          "validation": {
+            "required": true,
+            "pattern": "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$"
+          }
+        }
+      ]
+    },
+    {
+      "stepId": "step2",
+      "title": "Your Experience",
+      "fields": [
+        {
+          "fieldId": "rating",
+          "type": "radio",
+          "label": "How would you rate your overall experience?",
+          "options": [
+            { "label": "Excellent", "value": "excellent" },
+            { "label": "Good", "value": "good" },
+            { "label": "Average", "value": "average" },
+            { "label": "Poor", "value": "poor" }
+          ],
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "fieldId": "product",
+          "type": "dropdown",
+          "label": "Which product did you use?",
+          "options": [
+            { "label": "Select a product...", "value": "" },
+            { "label": "Product A", "value": "prod-a" },
+            { "label": "Product B", "value": "prod-b" },
+            { "label": "Product C", "value": "prod-c" }
+          ],
+          "validation": {
+            "required": true
+          }
+        }
+      ]
+    },
+    {
+      "stepId": "step3",
+      "title": "Feedback",
+      "fields": [
+        {
+          "fieldId": "comments",
+          "type": "textarea",
+          "label": "Do you have any additional comments or suggestions?",
+          "placeholder": "Your feedback is important to us...",
+          "validation": {
+            "required": false,
+            "maxLength": 500
+          }
+        }
+      ]
+    }
+  ],
+  "endScreen": {
+    "title": "Thank You!",
+    "description": "Your feedback has been recorded. You can now review your answers or submit.",
+    "reviewButtonText": "Review Answers",
+    "submitButtonText": "Submit"
+  }
+}


### PR DESCRIPTION
This commit introduces a Node.js build script (`build.js`) that bundles the entire survey application into a single, portable HTML file.

The script performs the following actions:
1.  Reads the main `index.html` file.
2.  Reads the `style.css` content and embeds it directly into the HTML within a `<style>` tag.
3.  Reads the `survey.json` data and embeds it into the HTML within a `<script type="application/json">` tag.
4.  Reads the `app.js` logic and embeds it directly into the HTML within a `<script>` tag.
5.  Outputs the final, self-contained file to `dist/survey.html`.

Additionally, `app.js` has been modified to load the survey configuration from the embedded JSON data instead of fetching an external file. This change makes the survey highly portable and easy to distribute.