### PR TITLE
feat: Enhance build script to accept CLI arguments

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,20 +1,68 @@
 const fs = require('fs');
 const path = require('path');
 
-const srcDir = path.join(__dirname, 'src');
-const distDir = path.join(__dirname, 'dist');
+/**
+ * Parses command line arguments into a key-value object.
+ * @param {string[]} argv - The process.argv array.
+ * @returns {object} - A map of arguments.
+ */
+function parseArgs(argv) {
+    const args = {};
+    for (let i = 2; i < argv.length; i++) {
+        const arg = argv[i];
+        if (arg.startsWith('--')) {
+            const key = arg.slice(2);
+            const value = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[i + 1] : true;
+            args[key] = value;
+            if (value !== true) i++; // Skip next value if it was consumed
+        }
+    }
+    return args;
+}
 
-const htmlFilePath = path.join(srcDir, 'index.html');
-const jsonFilePath = path.join(srcDir, 'survey.json');
-const cssFilePath = path.join(srcDir, 'style.css');
-const jsFilePath = path.join(srcDir, 'app.js');
+/**
+ * Resolves a user-provided path. If relative, it's prepended with '<cwd>/data/'.
+ * If no user path is given, it returns a path based on the default, relative to the script's directory.
+ * @param {string} userPath - The file path from the user argument.
+ * @param {string} defaultPath - The default path (e.g., 'src/survey.json').
+ * @returns {string} - The resolved absolute path.
+ */
+function resolvePath(userPath, defaultPath) {
+    if (userPath) {
+        // Path is provided by the user
+        if (path.isAbsolute(userPath)) {
+            return userPath;
+        } else {
+            // It's a relative path from the user, prepend <cwd>/data/
+            return path.join(process.cwd(), 'data', userPath);
+        }
+    }
+    // No user path, use the default path relative to the script's directory (__dirname)
+    return path.join(__dirname, defaultPath);
+}
 
-const outputHtmlPath = path.join(distDir, 'survey.html');
+// --- Main Execution ---
 
 try {
-    // 1. Ensure dist directory exists
-    if (!fs.existsSync(distDir)) {
-        fs.mkdirSync(distDir);
+    const args = parseArgs(process.argv);
+
+    // Resolve input and output paths
+    const jsonFilePath = resolvePath(args.input, 'src/survey.json');
+    const outputHtmlPath = resolvePath(args.output, 'dist/survey.html');
+
+    // The rest of the source files are assumed to be in the hardcoded `src` directory
+    const srcDir = path.join(__dirname, 'src');
+    const htmlFilePath = path.join(srcDir, 'index.html');
+    const cssFilePath = path.join(srcDir, 'style.css');
+    const jsFilePath = path.join(srcDir, 'app.js');
+
+    console.log(`Input survey JSON: ${jsonFilePath}`);
+    console.log(`Output HTML file: ${outputHtmlPath}`);
+
+    // 1. Ensure output directory exists
+    const outputDir = path.dirname(outputHtmlPath);
+    if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
     }
 
     // 2. Read all source files
@@ -24,18 +72,15 @@ try {
     const jsContent = fs.readFileSync(jsFilePath, 'utf8');
 
     // 3. Embed CSS
-    // Replace <link rel="stylesheet" href="style.css"> with <style>...</style>
     htmlContent = htmlContent.replace(
         '<link rel="stylesheet" href="style.css">',
         `<style>${cssContent}</style>`
     );
 
     // 4. Embed JSON data
-    // We will add a script tag with the JSON content before the main app script.
     const jsonScript = `<script id="survey-data" type="application/json">${jsonContent}</script>`;
 
     // 5. Embed JavaScript
-    // Replace <script src="app.js"></script> with <script>...</script>
     htmlContent = htmlContent.replace(
         '<script src="app.js"></script>',
         `${jsonScript}\n<script>${jsContent}</script>`
@@ -44,9 +89,9 @@ try {
     // 6. Write the final, self-contained HTML file
     fs.writeFileSync(outputHtmlPath, htmlContent);
 
-    console.log(`Successfully created self-contained survey at: ${outputHtmlPath}`);
+    console.log(`\nSuccessfully created self-contained survey at: ${outputHtmlPath}`);
 
 } catch (error) {
-    console.error('Error during build process:', error);
+    console.error('\nError during build process:', error.message);
     process.exit(1);
 }

--- a/data/test-output.html
+++ b/data/test-output.html
@@ -1,0 +1,503 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Survey</title>
+    <style>/* Basic styling for the survey app */
+body {
+    font-family: sans-serif;
+    background-color: #f4f4f9;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    margin: 0;
+}
+
+#survey-container {
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    width: 100%;
+    max-width: 600px;
+    padding: 2rem;
+    margin: 1rem;
+}
+
+#survey-header {
+    text-align: center;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 1rem;
+    margin-bottom: 1rem;
+}
+
+.survey-screen {
+    /* Screens are managed by JS */
+}
+
+button {
+    background-color: #007bff;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1rem;
+    margin-top: 1rem;
+}
+
+button:hover {
+    background-color: #0056b3;
+}
+
+#navigation-container {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 2rem;
+}
+
+.field-wrapper {
+    margin-bottom: 1.5rem;
+}
+
+.field-wrapper label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: bold;
+}
+
+.field-wrapper input[type="text"],
+.field-wrapper textarea,
+.field-wrapper select {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box; /* Important */
+}
+
+.field-wrapper input[type="radio"] {
+    margin-right: 0.5rem;
+}
+
+.error-message {
+    color: #dc3545;
+    font-size: 0.875rem;
+    margin-top: 0.25rem;
+    display: block; /* To ensure it appears on its own line */
+}
+
+#summary-container ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+#summary-container li {
+    background-color: #f8f9fa;
+    padding: 10px;
+    border-bottom: 1px solid #eee;
+}
+
+#summary-container li:last-child {
+    border-bottom: none;
+}
+</style>
+</head>
+<body>
+    <div id="survey-container">
+        <header id="survey-header">
+            <h1 id="survey-title"></h1>
+            <p id="survey-description"></p>
+        </header>
+
+        <main id="survey-main">
+            <!-- Start Screen: Initially visible -->
+            <div id="start-screen" class="survey-screen">
+                <h2 id="start-screen-title"></h2>
+                <p id="start-screen-description"></p>
+                <button id="start-button"></button>
+            </div>
+
+            <!-- Survey Screen: Initially hidden -->
+            <div id="survey-screen" class="survey-screen" style="display: none;">
+                <div id="step-header">
+                    <h3 id="step-title"></h3>
+                </div>
+                <div id="fields-container">
+                    <!-- Dynamic fields will be inserted here -->
+                </div>
+                <div id="navigation-container">
+                    <button id="back-button">Back</button>
+                    <button id="next-button">Next</button>
+                </div>
+            </div>
+
+            <!-- End Screen: Initially hidden -->
+            <div id="end-screen" class="survey-screen" style="display: none;">
+                <h2 id="end-screen-title"></h2>
+                <p id="end-screen-description"></p>
+                <div id="summary-container">
+                    <!-- Review of answers will be shown here -->
+                </div>
+                <button id="review-button"></button>
+                <button id="submit-button"></button>
+            </div>
+        </main>
+    </div>
+
+    <script id="survey-data" type="application/json">{
+  "surveyTitle": "My Test Survey",
+  "surveyDescription": "This is a test to verify the build script's argument handling.",
+  "startScreen": {
+    "title": "Test Start",
+    "description": "Click to begin the test.",
+    "buttonText": "Begin Test"
+  },
+  "steps": [
+    {
+      "stepId": "test-step",
+      "title": "Test Question",
+      "fields": [
+        {
+          "fieldId": "test-field",
+          "type": "text",
+          "label": "Did the test work?",
+          "placeholder": "Yes/No",
+          "validation": {
+            "required": true
+          }
+        }
+      ]
+    }
+  ],
+  "endScreen": {
+    "title": "Test Complete",
+    "description": "The test has finished.",
+    "submitButtonText": "Submit Test"
+  }
+}
+</script>
+<script>document.addEventListener('DOMContentLoaded', () => {
+    // State management
+    let surveyData = null;
+    let currentStepIndex = 0;
+    const userResponses = {};
+
+    // DOM element references
+    const surveyContainer = document.getElementById('survey-container');
+    const surveyTitleEl = document.getElementById('survey-title');
+    const surveyDescriptionEl = document.getElementById('survey-description');
+
+    const startScreen = document.getElementById('start-screen');
+    const startScreenTitleEl = document.getElementById('start-screen-title');
+    const startScreenDescriptionEl = document.getElementById('start-screen-description');
+    const startButton = document.getElementById('start-button');
+
+    const surveyScreen = document.getElementById('survey-screen');
+    const stepTitleEl = document.getElementById('step-title');
+    const fieldsContainer = document.getElementById('fields-container');
+    const backButton = document.getElementById('back-button');
+    const nextButton = document.getElementById('next-button');
+
+    const endScreen = document.getElementById('end-screen');
+    const endScreenTitleEl = document.getElementById('end-screen-title');
+    const endScreenDescriptionEl = document.getElementById('end-screen-description');
+    const summaryContainer = document.getElementById('summary-container');
+    const reviewButton = document.getElementById('review-button');
+    const submitButton = document.getElementById('submit-button');
+
+    /**
+     * Loads survey data from an embedded JSON script tag.
+     */
+    function loadSurveyFromEmbed() {
+        try {
+            const surveyDataEl = document.getElementById('survey-data');
+            if (!surveyDataEl) {
+                throw new Error('Survey data script tag not found.');
+            }
+            surveyData = JSON.parse(surveyDataEl.textContent);
+            initializeSurvey();
+        } catch (error) {
+            console.error("Could not load embedded survey data:", error);
+            surveyContainer.innerHTML = '<p>Error loading survey data. The file might be corrupted.</p>';
+        }
+    }
+
+    /**
+     * Initializes the survey by rendering the start screen.
+     */
+    function initializeSurvey() {
+        // Populate survey header
+        surveyTitleEl.textContent = surveyData.surveyTitle;
+        surveyDescriptionEl.textContent = surveyData.surveyDescription;
+
+        // Populate start screen
+        const { startScreen: startScreenData } = surveyData;
+        startScreenTitleEl.textContent = startScreenData.title;
+        startScreenDescriptionEl.textContent = startScreenData.description;
+        startButton.textContent = startScreenData.buttonText;
+
+        // Add event listeners
+        startButton.addEventListener('click', handleStart);
+        nextButton.addEventListener('click', handleNext);
+        backButton.addEventListener('click', handleBack);
+    }
+
+    /**
+     * Hides all screens and shows the one with the specified ID.
+     * @param {string} screenId - The ID of the screen to show.
+     */
+    function showScreen(screenId) {
+        document.querySelectorAll('.survey-screen').forEach(screen => {
+            screen.style.display = 'none';
+        });
+        document.getElementById(screenId).style.display = 'block';
+    }
+
+    /**
+     * Handles the start of the survey.
+     */
+    function handleStart() {
+        showScreen('survey-screen');
+        renderStep(currentStepIndex);
+    }
+
+    /**
+     * Renders a single step of the survey.
+     * @param {number} stepIndex - The index of the step to render.
+     */
+    function renderStep(stepIndex) {
+        const stepData = surveyData.steps[stepIndex];
+        stepTitleEl.textContent = stepData.title;
+        fieldsContainer.innerHTML = ''; // Clear previous fields
+
+        stepData.fields.forEach(field => {
+            const fieldEl = createField(field);
+            fieldsContainer.appendChild(fieldEl);
+        });
+
+        // Update navigation buttons
+        backButton.style.display = stepIndex === 0 ? 'none' : 'inline-block';
+        nextButton.textContent = (stepIndex === surveyData.steps.length - 1) ? 'Finish' : 'Next';
+    }
+
+    /**
+     * Creates the HTML element for a single field.
+     * @param {object} fieldData - The configuration for the field.
+     * @returns {HTMLElement} The created field element.
+     */
+    function createField(fieldData) {
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('field-wrapper');
+
+        const label = document.createElement('label');
+        label.textContent = fieldData.label;
+        label.setAttribute('for', fieldData.fieldId);
+        wrapper.appendChild(label);
+
+        let input;
+        switch (fieldData.type) {
+            case 'text':
+                input = document.createElement('input');
+                input.type = 'text';
+                input.placeholder = fieldData.placeholder || '';
+                break;
+            case 'textarea':
+                input = document.createElement('textarea');
+                input.placeholder = fieldData.placeholder || '';
+                break;
+            case 'radio':
+                // For radio, the wrapper contains multiple inputs
+                fieldData.options.forEach(option => {
+                    const radioWrapper = document.createElement('div');
+                    const radioInput = document.createElement('input');
+                    radioInput.type = 'radio';
+                    radioInput.name = fieldData.fieldId;
+                    radioInput.id = `${fieldData.fieldId}-${option.value}`;
+                    radioInput.value = option.value;
+
+                    const radioLabel = document.createElement('label');
+                    radioLabel.textContent = option.label;
+                    radioLabel.setAttribute('for', radioInput.id);
+
+                    radioWrapper.appendChild(radioInput);
+                    radioWrapper.appendChild(radioLabel);
+                    wrapper.appendChild(radioWrapper);
+                });
+                return wrapper; // Return early as the structure is different
+            case 'dropdown':
+                input = document.createElement('select');
+                fieldData.options.forEach(option => {
+                    const opt = document.createElement('option');
+                    opt.value = option.value;
+                    opt.textContent = option.label;
+                    input.appendChild(opt);
+                });
+                break;
+        }
+
+        if (input) {
+            input.id = fieldData.fieldId;
+            // Add validation attributes
+            if (fieldData.validation?.required) {
+                input.required = true;
+            }
+            if (fieldData.validation?.minLength) {
+                input.minLength = fieldData.validation.minLength;
+            }
+            if (fieldData.validation?.maxLength) {
+                input.maxLength = fieldData.validation.maxLength;
+            }
+            if (fieldData.validation?.pattern) {
+                input.pattern = fieldData.validation.pattern;
+            }
+            wrapper.appendChild(input);
+        }
+
+        const errorEl = document.createElement('span');
+        errorEl.classList.add('error-message');
+        errorEl.id = `${fieldData.fieldId}-error`;
+        wrapper.appendChild(errorEl);
+
+        return wrapper;
+    }
+
+    /**
+     * Validates the current step, saves responses, and then proceeds.
+     */
+    function handleNext() {
+        if (validateAndSaveStep()) {
+            if (currentStepIndex < surveyData.steps.length - 1) {
+                currentStepIndex++;
+                renderStep(currentStepIndex);
+            } else {
+                renderEndScreen();
+            }
+        }
+    }
+
+    /**
+     * Validates fields in the current step and saves their values.
+     * @returns {boolean} - True if validation passes, false otherwise.
+     */
+    function validateAndSaveStep() {
+        let isValid = true;
+        const stepData = surveyData.steps[currentStepIndex];
+
+        // Clear previous errors for this step
+        stepData.fields.forEach(field => {
+            const errorEl = document.getElementById(`${field.fieldId}-error`);
+            if (errorEl) errorEl.textContent = '';
+        });
+
+        for (const field of stepData.fields) {
+            const fieldEl = document.getElementById(field.fieldId);
+            let value;
+            let fieldIsValid = true;
+
+            if (field.type === 'radio') {
+                const checkedRadio = document.querySelector(`input[name="${field.fieldId}"]:checked`);
+                value = checkedRadio ? checkedRadio.value : null;
+            } else {
+                value = fieldEl.value;
+            }
+
+            // Save response
+            userResponses[field.fieldId] = value;
+
+            // Perform validation
+            if (field.validation?.required && !value) {
+                fieldIsValid = false;
+                showError(field.fieldId, 'This field is required.');
+            } else if (value) {
+                if (field.validation?.minLength && value.length < field.validation.minLength) {
+                    fieldIsValid = false;
+                    showError(field.fieldId, `Must be at least ${field.validation.minLength} characters.`);
+                }
+                if (field.validation?.maxLength && value.length > field.validation.maxLength) {
+                    fieldIsValid = false;
+                    showError(field.fieldId, `Cannot exceed ${field.validation.maxLength} characters.`);
+                }
+                if (field.validation?.pattern) {
+                    const regex = new RegExp(field.validation.pattern);
+                    if (!regex.test(value)) {
+                        fieldIsValid = false;
+                        showError(field.fieldId, 'Invalid format.');
+                    }
+                }
+            }
+
+            if (!fieldIsValid) isValid = false;
+        }
+
+        return isValid;
+    }
+
+    /**
+     * Displays an error message for a specific field.
+     * @param {string} fieldId - The ID of the field.
+     * @param {string} message - The error message to display.
+     */
+    function showError(fieldId, message) {
+        const errorEl = document.getElementById(`${fieldId}-error`);
+        if (errorEl) {
+            errorEl.textContent = message;
+        }
+    }
+
+    /**
+     * Handles the back button click.
+     */
+    function handleBack() {
+        if (currentStepIndex > 0) {
+            currentStepIndex--;
+            renderStep(currentStepIndex);
+        }
+    }
+
+    /**
+     * Renders the final screen of the survey.
+     */
+    function renderEndScreen() {
+        showScreen('end-screen');
+        const { endScreen: endScreenData } = surveyData;
+        endScreenTitleEl.textContent = endScreenData.title;
+        endScreenDescriptionEl.textContent = endScreenData.description;
+        reviewButton.textContent = endScreenData.reviewButtonText;
+        submitButton.textContent = endScreenData.submitButtonText;
+
+        // Render summary
+        summaryContainer.innerHTML = ''; // Clear previous summary
+        const summaryList = document.createElement('ul');
+
+        surveyData.steps.forEach(step => {
+            step.fields.forEach(field => {
+                const response = userResponses[field.fieldId];
+                if (response) {
+                    const listItem = document.createElement('li');
+
+                    let responseText = response;
+                    if (field.type === 'radio' || field.type === 'dropdown') {
+                        const option = field.options.find(o => o.value === response);
+                        responseText = option ? option.label : response;
+                    }
+
+                    listItem.innerHTML = `<strong>${field.label}:</strong> ${responseText}`;
+                    summaryList.appendChild(listItem);
+                }
+            });
+        });
+
+        summaryContainer.appendChild(summaryList);
+
+        // TODO: Implement final submission logic for the submitButton
+        // TODO: Implement logic for reviewButton to go back to a specific step
+    }
+
+    // Initial load
+    loadSurveyFromEmbed();
+});
+</script>
+</body>
+</html>

--- a/data/test-survey.json
+++ b/data/test-survey.json
@@ -1,0 +1,31 @@
+{
+  "surveyTitle": "My Test Survey",
+  "surveyDescription": "This is a test to verify the build script's argument handling.",
+  "startScreen": {
+    "title": "Test Start",
+    "description": "Click to begin the test.",
+    "buttonText": "Begin Test"
+  },
+  "steps": [
+    {
+      "stepId": "test-step",
+      "title": "Test Question",
+      "fields": [
+        {
+          "fieldId": "test-field",
+          "type": "text",
+          "label": "Did the test work?",
+          "placeholder": "Yes/No",
+          "validation": {
+            "required": true
+          }
+        }
+      ]
+    }
+  ],
+  "endScreen": {
+    "title": "Test Complete",
+    "description": "The test has finished.",
+    "submitButtonText": "Submit Test"
+  }
+}


### PR DESCRIPTION
The `build.js` script has been refactored to be more flexible and powerful. It now accepts command-line arguments to specify the input survey file and the output HTML file path.

Key changes:
- The script now parses `--input` and `--output` arguments from the command line.
- If no arguments are provided, it falls back to the default project structure (`src/survey.json` and `dist/survey.html`).
- It implements special path handling: if a user provides a *relative* path for the input or output, it is resolved relative to a `data/` subdirectory in the current working directory. Absolute paths are used as-is.
- The path resolution logic has been made more robust to correctly distinguish between default paths and user-provided paths.

This allows users to generate multiple, different survey bundles from various JSON configurations without modifying the script, for example: `node build.js --input my-special-survey.json --output my-special-survey.html`